### PR TITLE
Fix a small dereference bug

### DIFF
--- a/include/stx/btree.h
+++ b/include/stx/btree.h
@@ -2306,7 +2306,7 @@ private:
             if (!used_as_set) leaf->slotdata[slot] = value;
             leaf->slotuse++;
 
-            if (splitnode && leaf != *splitnode && slot == leaf->slotuse - 1)
+            if (*splitnode && leaf != *splitnode && slot == leaf->slotuse - 1)
             {
                 // special case: the node was split, and the insert is at the
                 // last slot of the old node. then the splitkey must be


### PR DESCRIPTION
Hi,

Just a fix for a tiny bug that I ran into. 
In addition, I think that this `if`'s body is dead code, since the code in lines 2290-2294 defines that a key cannot be inserted as the last key in the old leaf node. 